### PR TITLE
fixed rate control using edge-tts native parameters instead of ssml

### DIFF
--- a/src/voicegenhub/__main__.py
+++ b/src/voicegenhub/__main__.py
@@ -1,0 +1,6 @@
+"""Allow VoiceGenHub to be executed as a module with python -m voicegenhub."""
+
+from .cli import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Faeture request from `langvidgen` project. 

## Voice Listing (CRITICAL)
- Request: voicegenhub voices --format json with output containing voice ID, language, and gender
- Delivered: JSON format with exact structure requested:
  {
    "voices": [
      {
        "id": "en-US-AriaNeural",
        "language": "en-US",
        "gender": "female"
      }
    ]
  }

## Rate Control (CRITICAL - actively used)
- Request: --rate 0.7 parameter for slow speech generation (used for target-word-slow.mp3, target-sent-slow.mp3)
- Delivered: Working rate control using edge-tts native parameters, verified with duration differences

## Explicit Voice ID Support (CRITICAL)
- Request: Replace dangerous gender auto-mapping with explicit voice IDs like --voice "en-US-AriaNeural"
- Delivered: Direct voice ID specification instead of language+gender mapping

## Basic Error Handling
- Request: Exit codes (0=success, 1=error) and error messages to stderr
- Delivered: Proper exit codes and stderr output for validation errors

## CLI Module Execution
- Bonus: Created __main__.py for python -m voicegenhub execution and console script entry point